### PR TITLE
The changes in this pr will enable the users to use and style the embedded toolbar separately.

### DIFF
--- a/src/lib/shad-editor/editor-toolbar.svelte
+++ b/src/lib/shad-editor/editor-toolbar.svelte
@@ -27,14 +27,16 @@
 	import Video from './icons/video.svelte';
 	import FontSize from './icons/font-size.svelte';
 	import Audio from './icons/audio.svelte';
+	import { cn } from '$lib/utils.js';
 	interface Props {
 		editor: Editor;
+		class?: String;
 	}
 
-	let { editor }: Props = $props();
+	let { editor, class: className = '' }: Props = $props();
 </script>
 
-<div class="flex w-full items-center overflow-auto border-b p-1 *:mx-1">
+<div class={cn('flex w-full items-center overflow-auto border-b p-1 *:mx-1', className)}>
 	<Undo {editor} />
 	<Redo {editor} />
 	<Separator orientation="vertical" class="h-fit" />

--- a/src/lib/shad-editor/shad-editor.svelte
+++ b/src/lib/shad-editor/shad-editor.svelte
@@ -59,16 +59,19 @@
 		content?: Content;
 		showToolbar?: boolean;
 		editable?: boolean;
+		showAllMenus?: boolean;
+		editor?: Editor;
 	}
 
 	let {
 		class: className = '',
 		content = $bindable(''),
 		showToolbar = true,
-		editable = true
+		editable = true,
+		showAllMenus = true,
+		editor = $bindable()
 	}: Props = $props();
 
-	let editor = $state<Editor>();
 	let element = $state<HTMLElement>();
 
 	onMount(() => {
@@ -194,7 +197,7 @@
 </script>
 
 <div class={cn('flex flex-col rounded border', className)}>
-	{#if editor && showToolbar}
+	{#if editor && showAllMenus}
 		{#if showToolbar}
 			<EditorToolbar {editor} />
 		{/if}


### PR DESCRIPTION
Following changes have been done:
- A new boolean "showAllMenus" is created which controls the showing of all menus.
- boolean "showToolbar" now only controls the Editor Toolbar itself and not the other menus.
- "editor" is now a bindable, taken from the props as an optional value. This is done so that a variable clould be bound to <ShadEdtior> and then that variable could be used while using EditorToolbar separately.
- class is taken through props in EditorToolbar svelte file to allow users to style it. It is merged with default styles using the method used in other files in the code.