### PR TITLE
feat: add support for extra extensions to UI options(headless & shadcn)

### DIFF
--- a/src/lib/edra/headless/editor.svelte
+++ b/src/lib/edra/headless/editor.svelte
@@ -44,7 +44,8 @@
 		content,
 		onUpdate,
 		autofocus = false,
-		class: className
+		class: className,
+		extensions
 	}: EdraEditorProps = $props();
 
 	onMount(() => {
@@ -67,7 +68,8 @@
 				AudioExtended(AudioExtendedComp),
 				IFramePlaceholder(IFramePlaceHolderComp),
 				IFrameExtended(IFrameExtendedComp),
-				slashcommand(SlashCommandList)
+				slashcommand(SlashCommandList),
+				...(extensions ?? [])
 			],
 			{
 				onUpdate,

--- a/src/lib/edra/shadcn/editor.svelte
+++ b/src/lib/edra/shadcn/editor.svelte
@@ -45,7 +45,8 @@
 		content,
 		onUpdate,
 		autofocus = false,
-		class: className
+		class: className,
+		extensions
 	}: EdraEditorProps = $props();
 
 	onMount(() => {
@@ -68,7 +69,8 @@
 				AudioExtended(AudioExtendedComp),
 				IFramePlaceholder(IFramePlaceHolderComp),
 				IFrameExtended(IFrameExtendedComp),
-				slashcommand(SlashCommandList)
+				slashcommand(SlashCommandList),
+				...(extensions ?? [])
 			],
 			{
 				onUpdate,

--- a/src/lib/edra/types.ts
+++ b/src/lib/edra/types.ts
@@ -1,4 +1,4 @@
-import type { Content, Editor } from '@tiptap/core';
+import type { Content, Editor, Extensions } from '@tiptap/core';
 import type { EditorState } from '@tiptap/pm/state';
 import type { EditorView } from '@tiptap/pm/view';
 import type { Snippet } from 'svelte';
@@ -10,6 +10,7 @@ export interface EdraEditorProps {
 	autofocus?: boolean;
 	onUpdate?: () => void;
 	class?: string;
+	extensions?: Extensions;
 }
 
 export interface EdraToolbarProps {


### PR DESCRIPTION
This is a small change to allow adding extra extensions to the headless and shadcn UI options without requiring creation of new components. 