### PR TITLE
fix(cli): correct wrong pnpm args

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -62,7 +62,7 @@ async function installDependencies() {
 			installCommand = `npm install ${dependencies.join(' ')} --legacy-peer-deps`;
 			break;
 		case 'pnpm':
-			installCommand = `pnpm add ${dependencies.join(' ')} --legacy-peer-deps`;
+			installCommand = `pnpm add ${dependencies.join(' ')} --strict-peer-dependencies=false`;
 			break;
 		case 'yarn':
 			installCommand = `yarn add ${dependencies.join(' ')}`;


### PR DESCRIPTION
pnpm doesn't have `--legacy-peer-deps` option, causing the install command to fail. Replaced the argument to `--strict-peer-dependencies=false`, which is the equivalent of `--legacy-peer-deps`.